### PR TITLE
Avoid duplicate copies for Paket compatibility

### DIFF
--- a/src/Yarn.MSBuild/Yarn.MSBuild.nuspec
+++ b/src/Yarn.MSBuild/Yarn.MSBuild.nuspec
@@ -28,8 +28,6 @@ This package bundles Yarn so MSBuild projects can invoke yarn without needing to
     <file src="build\" target="build/" />
     <file src="buildMultiTargeting\" target="buildMultiTargeting/" />
     <!-- List at least these files to ensure that dist was extracted to the right place. pack will fail if they are missing-->
-    <file src="dist/bin/yarn.cmd" target="dist/bin/" />
-    <file src="dist/bin/yarn" target="dist/bin/" />
     <file src="dist\" target="dist/" />
     <file src="third_party_notice.txt" target="/" />
   </files>


### PR DESCRIPTION
Works fine with NuGet, but currently leads to this error on install with Paket (https://fsprojects.github.io/Paket/):

    In rare cases a firewall might have blocked the download. Please look into the file and see if it contains text with further information.
-> IOException: Zip entry name ends in directory separator character but contains data.

https://github.com/natemcmaster/Yarn.MSBuild/issues/6