### PR TITLE
Make it work with Visual Studio 2015

### DIFF
--- a/build.ps1
+++ b/build.ps1
@@ -2,6 +2,8 @@
 
 $ErrorActionPreference = 'Stop'
 Set-StrictMode -Version 2
+# github requires TLS 1.2
+[Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
 function __exec($cmd) {
     write-host -ForegroundColor Cyan "> $cmd $args"

--- a/src/Yarn.MSBuild/build/Yarn.MSBuild.props
+++ b/src/Yarn.MSBuild/build/Yarn.MSBuild.props
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <!-- set in your project to override location of yarn file-->
     <YarnWorkingDir Condition=" '$(YarnWorkingDir)' != '' ">$(MSBuildProjectDirectory)</YarnWorkingDir>

--- a/src/Yarn.MSBuild/build/Yarn.MSBuild.props
+++ b/src/Yarn.MSBuild/build/Yarn.MSBuild.props
@@ -7,7 +7,6 @@
     <_YarnTaskAssembly Condition="'$(MSBuildRuntimeType)' != 'Core'">..\tools\net46\Yarn.MSBuild.dll</_YarnTaskAssembly>
 
     <YarnExecutablePath>$(MSBuildThisFileDirectory)..\dist\bin\yarn</YarnExecutablePath>
-    <YarnExecutablePath>$([MSBuild]::NormalizePath($(YarnExecutablePath)))</YarnExecutablePath>
     <YarnExecutablePath Condition="'$(OS)' == 'Windows_NT'">$(YarnExecutablePath).cmd</YarnExecutablePath>
   </PropertyGroup>
 

--- a/src/Yarn.MSBuild/build/Yarn.MSBuild.targets
+++ b/src/Yarn.MSBuild/build/Yarn.MSBuild.targets
@@ -1,4 +1,4 @@
-<Project>
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <BuildDependsOn>
         YarnBuild;


### PR DESCRIPTION
Build with Visual Studio 2015 or MSBuild 14.0 fails if there's no `xmlns` in `<Project>` tag.
`NormalizePath` is missing in MSbuild 14.

Also [github now requires TLS 1.2](https://githubengineering.com/crypto-removal-notice/).